### PR TITLE
Gas optimizations

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -7,3 +7,6 @@ compiler:
         optimizer:
             enabled: true
             runs: 1000000
+
+dependencies:
+  - OpenZeppelin/openzeppelin-contracts@3.0.1

--- a/contracts/LiquidERC20.sol
+++ b/contracts/LiquidERC20.sol
@@ -68,12 +68,12 @@ contract LiquidERC20 is ERC20PointerSupply {
         returns (uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(maxTokens > 0); // dev: no tokens to add
-        require(msg.value > 0); // dev: no ether to add
+        require(maxTokens != 0); // dev: no tokens to add
+        require(msg.value != 0); // dev: no ether to add
         uint256 totalLiquidity = _poolTotalSupply;
 
-        if (totalLiquidity > 0) {
-            require(minLiquidity > 0); // dev: no min_liquidity specified
+        if (totalLiquidity != 0) {
+            require(minLiquidity != 0); // dev: no min_liquidity specified
             uint256 ethReserve = address(this).balance.sub(msg.value);
             uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
             uint256 tokenAmount = msg.value.mul(tokenReserve).div(ethReserve).add(1);
@@ -131,11 +131,11 @@ contract LiquidERC20 is ERC20PointerSupply {
         returns (uint256, uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(amount > 0); // dev: amount of liquidity to remove must be positive
-        require(minEth > 0); // dev: must remove positive eth amount
-        require(minTokens > 0); // dev: must remove positive token amount
+        require(amount != 0); // dev: amount of liquidity to remove must be positive
+        require(minEth != 0); // dev: must remove positive eth amount
+        require(minTokens != 0); // dev: must remove positive token amount
         uint256 totalLiquidity = _poolTotalSupply;
-        require(totalLiquidity > 0); // dev: no liquidity to remove
+        require(totalLiquidity != 0); // dev: no liquidity to remove
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethAmount = amount.mul(address(this).balance).div(totalLiquidity);
         uint256 tokenAmount = amount.mul(tokenReserve).div(totalLiquidity);
@@ -172,7 +172,7 @@ contract LiquidERC20 is ERC20PointerSupply {
         pure
         returns (uint256)
     {
-        require(inputReserve > 0); // dev: no inputReserve provided
+        require(inputReserve != 0); // dev: no inputReserve provided
         uint256 inputAmountWithFee = inputAmount.mul(995);
         uint256 numerator = inputAmountWithFee.mul(outputReserve);
         uint256 denominator = inputReserve.mul(1000).add(inputAmountWithFee);
@@ -186,8 +186,8 @@ contract LiquidERC20 is ERC20PointerSupply {
         pure
         returns (uint256)
     {
-        require(inputReserve > 0); // dev: no inputReserve provided
-        require(outputReserve > 0); // dev: no outputReserve provided
+        require(inputReserve != 0); // dev: no inputReserve provided
+        require(outputReserve != 0); // dev: no outputReserve provided
         uint256 numerator = inputReserve.mul(outputAmount).mul(1000);
         uint256 denominator = outputReserve.sub(outputAmount).mul(995);
         return numerator.div(denominator).add(1);
@@ -208,8 +208,8 @@ contract LiquidERC20 is ERC20PointerSupply {
         returns (uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(ethSold > 0); // dev: no eth to sell
-        require(minTokens > 0); // dev: must buy one or more tokens
+        require(ethSold != 0); // dev: no eth to sell
+        require(minTokens != 0); // dev: must buy one or more tokens
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethReserve = address(this).balance.sub(ethSold);
         uint256 tokensBought = getInputPrice(ethSold, ethReserve, tokenReserve);
@@ -277,15 +277,15 @@ contract LiquidERC20 is ERC20PointerSupply {
         returns (uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(tokensBought > 0); // dev: must buy one or more tokens
-        require(maxEth > 0); // dev: maxEth must greater than 0
+        require(tokensBought != 0); // dev: must buy one or more tokens
+        require(maxEth != 0); // dev: maxEth must greater than 0
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethReserve = address(this).balance.sub(maxEth);
         uint256 ethSold = getOutputPrice(tokensBought, ethReserve, tokenReserve);
         uint256 ethRefund = maxEth.sub(ethSold, "LGT: not enough ETH to buy tokens");
         _balances[recipient] += tokensBought;
         _ownedSupply += tokensBought;
-        if (ethRefund > 0) {
+        if (ethRefund != 0) {
             buyer.transfer(ethRefund);
         }
         return ethSold;
@@ -344,8 +344,8 @@ contract LiquidERC20 is ERC20PointerSupply {
         address payable recipient
     ) internal returns (uint256) {
         require(deadline >= now); // dev: deadline passed
-        require(tokensSold > 0); // dev: must sell one or more tokens
-        require(minEth > 0); // dev: minEth not set
+        require(tokensSold != 0); // dev: must sell one or more tokens
+        require(minEth != 0); // dev: minEth not set
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethBought = getInputPrice(tokensSold, tokenReserve, address(this).balance);
         require(ethBought >= minEth); // dev: tokens not worth enough
@@ -404,7 +404,7 @@ contract LiquidERC20 is ERC20PointerSupply {
         address payable recipient
     ) internal returns (uint256) {
         require(deadline >= now); // dev: deadline passed
-        require(ethBought > 0); // dev: must buy more than 0 eth
+        require(ethBought != 0); // dev: must buy more than 0 eth
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 tokensSold = getOutputPrice(ethBought, tokenReserve, address(this).balance);
         require(maxTokens >= tokensSold); // dev: need more tokens to sell
@@ -463,7 +463,7 @@ contract LiquidERC20 is ERC20PointerSupply {
     /// @param ethSold The exact amount of ether you are selling.
     /// @return The amount of tokens that can be bought with `ethSold` ether.
     function getEthToTokenInputPrice(uint256 ethSold) public view returns(uint256) {
-        require(ethSold > 0); // dev: no eth to sell
+        require(ethSold != 0); // dev: no eth to sell
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         return getInputPrice(ethSold, address(this).balance, tokenReserve);
     }
@@ -480,7 +480,7 @@ contract LiquidERC20 is ERC20PointerSupply {
     /// @param tokensSold The exact amount of tokens you are selling.
     /// @return The amount of ether you receive for selling `tokensSold` tokens.
     function getTokenToEthInputPrice(uint256 tokensSold) public view returns (uint256) {
-        require(tokensSold > 0); // dev: can't sell less than one token
+        require(tokensSold != 0); // dev: can't sell less than one token
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         return getInputPrice(tokensSold, tokenReserve, address(this).balance);
     }

--- a/contracts/LiquidERC20.sol
+++ b/contracts/LiquidERC20.sol
@@ -74,7 +74,7 @@ contract LiquidERC20 is ERC20PointerSupply {
 
         if (totalLiquidity != 0) {
             require(minLiquidity != 0); // dev: no min_liquidity specified
-            uint256 ethReserve = address(this).balance.sub(msg.value);
+            uint256 ethReserve = address(this).balance - msg.value;
             uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
             uint256 tokenAmount = msg.value.mul(tokenReserve).div(ethReserve).add(1);
             uint256 liquidityCreated = msg.value.mul(totalLiquidity).div(ethReserve);

--- a/contracts/LiquidGasToken.sol
+++ b/contracts/LiquidGasToken.sol
@@ -177,7 +177,7 @@ contract LiquidGasToken is LiquidERC20 {
         // uint256 totalMinted = _totalMinted; //stack too deep, this would save ~800 gas
         tokenAmount = maxTokens;
         if (totalLiquidity != 0) {
-            uint256 ethReserve = address(this).balance.sub(msg.value);
+            uint256 ethReserve = address(this).balance - msg.value;
             uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
             ethAmount = maxTokens.mul(ethReserve).div(tokenReserve).sub(1);
             if (ethAmount > msg.value) {
@@ -346,7 +346,7 @@ contract LiquidGasToken is LiquidERC20 {
         if (tokenReserve < amount) {
             return 0;
         }
-        uint256 ethReserve = address(this).balance.sub(msg.value);
+        uint256 ethReserve = address(this).balance - msg.value;
         uint256 ethSold = getOutputPrice(amount, ethReserve, tokenReserve);
         if (msg.value < ethSold) {
             return 0;
@@ -375,7 +375,7 @@ contract LiquidGasToken is LiquidERC20 {
         if (maxTokens == 0 || deadline <= now) {
             return 0;
         }
-        uint256 ethReserve = address(this).balance.sub(msg.value);
+        uint256 ethReserve = address(this).balance - msg.value;
         uint256 totalBurned = _totalBurned;
         uint256 tokenReserve = _totalMinted.sub(totalBurned).sub(_ownedSupply);
         uint256 tokensBought = getInputPrice(msg.value, ethReserve, tokenReserve);

--- a/contracts/LiquidGasToken.sol
+++ b/contracts/LiquidGasToken.sol
@@ -176,7 +176,6 @@ contract LiquidGasToken is LiquidERC20 {
         uint256 totalLiquidity = _poolTotalSupply;
         // uint256 totalMinted = _totalMinted; //stack too deep, this would save ~800 gas
         tokenAmount = maxTokens;
-        ethAmount = msg.value;
         if (totalLiquidity != 0) {
             uint256 ethReserve = address(this).balance.sub(msg.value);
             uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
@@ -191,6 +190,7 @@ contract LiquidGasToken is LiquidERC20 {
         } else {
             require(msg.value > 1000000000); // dev: initial eth below 1 gwei
             liquidityCreated = address(this).balance;
+            ethAmount = msg.value;
         }
 
         // Mint tokens directly to the liquidity pool

--- a/contracts/LiquidGasToken.sol
+++ b/contracts/LiquidGasToken.sol
@@ -169,15 +169,15 @@ contract LiquidGasToken is LiquidERC20 {
         returns (uint256 tokenAmount, uint256 ethAmount, uint256 liquidityCreated)
     {
         require(deadline >= now); // dev: deadline passed
-        require(maxTokens > 0); // dev: can't mint less than 1 token
-        require(msg.value > 0); // dev: must provide ether to add liquidity
+        require(maxTokens != 0); // dev: can't mint less than 1 token
+        require(msg.value != 0); // dev: must provide ether to add liquidity
 
         // calculate optimum values for tokens and ether to add
         uint256 totalLiquidity = _poolTotalSupply;
         // uint256 totalMinted = _totalMinted; //stack too deep, this would save ~800 gas
         tokenAmount = maxTokens;
         ethAmount = msg.value;
-        if (totalLiquidity > 0) {
+        if (totalLiquidity != 0) {
             uint256 ethReserve = address(this).balance.sub(msg.value);
             uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
             ethAmount = maxTokens.mul(ethReserve).div(tokenReserve).sub(1);
@@ -234,7 +234,7 @@ contract LiquidGasToken is LiquidERC20 {
         returns (uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(amount > 0); // dev: must sell one or more tokens
+        require(amount != 0); // dev: must sell one or more tokens
         uint256 totalMinted = _totalMinted;
         uint256 tokenReserve = totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethBought = getInputPrice(amount, tokenReserve, address(this).balance);
@@ -263,7 +263,7 @@ contract LiquidGasToken is LiquidERC20 {
         returns (uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(amount > 0); // dev: must sell one or more tokens
+        require(amount != 0); // dev: must sell one or more tokens
         uint256 totalMinted = _totalMinted;
         uint256 tokenReserve = totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethBought = getInputPrice(amount, tokenReserve, address(this).balance);
@@ -338,7 +338,7 @@ contract LiquidGasToken is LiquidERC20 {
         payable
         returns (uint256)
     {
-        if (deadline <= now || amount <= 0) {
+        if (amount == 0 || deadline <= now) {
             return 0;
         }
         uint256 totalBurned = _totalBurned;
@@ -353,7 +353,7 @@ contract LiquidGasToken is LiquidERC20 {
         }
         uint256 ethRefund = msg.value - ethSold;
         _destroyContracts(amount, totalBurned);
-        if (ethRefund > 0) {
+        if (ethRefund != 0) {
             refundTo.transfer(ethRefund);
         }
         return ethSold;
@@ -372,14 +372,14 @@ contract LiquidGasToken is LiquidERC20 {
         payable
         returns (uint256)
     {
-        if (deadline <= now || maxTokens <= 0) {
+        if (maxTokens == 0 || deadline <= now) {
             return 0;
         }
         uint256 ethReserve = address(this).balance.sub(msg.value);
         uint256 totalBurned = _totalBurned;
         uint256 tokenReserve = _totalMinted.sub(totalBurned).sub(_ownedSupply);
         uint256 tokensBought = getInputPrice(msg.value, ethReserve, tokenReserve);
-        if (tokensBought <= 0) {
+        if (tokensBought == 0) {
             return 0;
         } else if (tokensBought > maxTokens) {
             tokensBought = maxTokens;


### PR DESCRIPTION
* favor equality vs greater-than / less-than comparisons with zero in order to take advantage of `ISZERO` instruction
* reorder `||` if test conditions so cheaper evaluation comes first - saves gas from short circuiting
* remove `ethReserve` local variable in `mintToSellTo` - repeated calls to `SELFBALANCE` and `CALLVALUE` cost less than the multiple `SLOAD`s required from `_totalMinted`
* remove some redundant safemath checks