### PR TITLE
Gas optimizations

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -7,3 +7,6 @@ compiler:
         optimizer:
             enabled: true
             runs: 1000000
+
+dependencies:
+  - OpenZeppelin/openzeppelin-contracts@3.0.1

--- a/contracts/ERC20PointerSupply.sol
+++ b/contracts/ERC20PointerSupply.sol
@@ -107,7 +107,7 @@ contract ERC20PointerSupply is IERC20 {
         _approve(
             sender,
             msg.sender,
-            _allowances[sender][msg.sender].sub(amount, "ERC20: transfer amount exceeds allowance")
+            _allowances[sender][msg.sender].sub(amount, "ERC20: exceeds allowance")
         );
         return true;
     }
@@ -140,7 +140,7 @@ contract ERC20PointerSupply is IERC20 {
         _approve(
             msg.sender,
             spender,
-            _allowances[msg.sender][spender].sub(subtractedValue, "ERC20: decreased allowance below zero")
+            _allowances[msg.sender][spender].sub(subtractedValue, "ERC20: allowance below zero")
         );
         return true;
     }
@@ -150,17 +150,14 @@ contract ERC20PointerSupply is IERC20 {
     //        ------------------------
 
     function _transfer(address sender, address recipient, uint256 amount) internal virtual {
-        require(sender != address(0), "ERC20: transfer from the zero address");
-        require(recipient != address(0), "ERC20: transfer to the zero address");
+        require(recipient != address(0), "ERC20: transfer to zero address");
 
-        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer exceeds balance");
         _balances[recipient] += amount;
         emit Transfer(sender, recipient, amount);
     }
 
     function _approve(address owner, address spender, uint256 amount) internal virtual {
-        require(owner != address(0), "ERC20: approve from the zero address");
-        require(spender != address(0), "ERC20: approve to the zero address");
 
         _allowances[owner][spender] = amount;
         emit Approval(owner, spender, amount);

--- a/contracts/LiquidERC20.sol
+++ b/contracts/LiquidERC20.sol
@@ -68,12 +68,12 @@ contract LiquidERC20 is ERC20PointerSupply {
         returns (uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(maxTokens > 0); // dev: no tokens to add
-        require(msg.value > 0); // dev: no ether to add
+        require(maxTokens != 0); // dev: no tokens to add
+        require(msg.value != 0); // dev: no ether to add
         uint256 totalLiquidity = _poolTotalSupply;
 
-        if (totalLiquidity > 0) {
-            require(minLiquidity > 0); // dev: no min_liquidity specified
+        if (totalLiquidity != 0) {
+            require(minLiquidity != 0); // dev: no min_liquidity specified
             uint256 ethReserve = address(this).balance.sub(msg.value);
             uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
             uint256 tokenAmount = msg.value.mul(tokenReserve).div(ethReserve).add(1);
@@ -131,11 +131,11 @@ contract LiquidERC20 is ERC20PointerSupply {
         returns (uint256, uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(amount > 0); // dev: amount of liquidity to remove must be positive
-        require(minEth > 0); // dev: must remove positive eth amount
-        require(minTokens > 0); // dev: must remove positive token amount
+        require(amount != 0); // dev: amount of liquidity to remove must be positive
+        require(minEth != 0); // dev: must remove positive eth amount
+        require(minTokens != 0); // dev: must remove positive token amount
         uint256 totalLiquidity = _poolTotalSupply;
-        require(totalLiquidity > 0); // dev: no liquidity to remove
+        require(totalLiquidity != 0); // dev: no liquidity to remove
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethAmount = amount.mul(address(this).balance).div(totalLiquidity);
         uint256 tokenAmount = amount.mul(tokenReserve).div(totalLiquidity);
@@ -172,7 +172,7 @@ contract LiquidERC20 is ERC20PointerSupply {
         pure
         returns (uint256)
     {
-        require(inputReserve > 0); // dev: no inputReserve provided
+        require(inputReserve != 0); // dev: no inputReserve provided
         uint256 inputAmountWithFee = inputAmount.mul(995);
         uint256 numerator = inputAmountWithFee.mul(outputReserve);
         uint256 denominator = inputReserve.mul(1000).add(inputAmountWithFee);
@@ -186,8 +186,8 @@ contract LiquidERC20 is ERC20PointerSupply {
         pure
         returns (uint256)
     {
-        require(inputReserve > 0); // dev: no inputReserve provided
-        require(outputReserve > 0); // dev: no outputReserve provided
+        require(inputReserve != 0); // dev: no inputReserve provided
+        require(outputReserve != 0); // dev: no outputReserve provided
         uint256 numerator = inputReserve.mul(outputAmount).mul(1000);
         uint256 denominator = outputReserve.sub(outputAmount).mul(995);
         return numerator.div(denominator).add(1);
@@ -208,8 +208,8 @@ contract LiquidERC20 is ERC20PointerSupply {
         returns (uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(ethSold > 0); // dev: no eth to sell
-        require(minTokens > 0); // dev: must buy one or more tokens
+        require(ethSold != 0); // dev: no eth to sell
+        require(minTokens != 0); // dev: must buy one or more tokens
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethReserve = address(this).balance.sub(ethSold);
         uint256 tokensBought = getInputPrice(ethSold, ethReserve, tokenReserve);
@@ -277,15 +277,15 @@ contract LiquidERC20 is ERC20PointerSupply {
         returns (uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(tokensBought > 0); // dev: must buy one or more tokens
-        require(maxEth > 0); // dev: maxEth must greater than 0
+        require(tokensBought != 0); // dev: must buy one or more tokens
+        require(maxEth != 0); // dev: maxEth must greater than 0
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethReserve = address(this).balance.sub(maxEth);
         uint256 ethSold = getOutputPrice(tokensBought, ethReserve, tokenReserve);
         uint256 ethRefund = maxEth.sub(ethSold, "LGT: not enough ETH to buy tokens");
         _balances[recipient] += tokensBought;
         _ownedSupply += tokensBought;
-        if (ethRefund > 0) {
+        if (ethRefund != 0) {
             buyer.transfer(ethRefund);
         }
         return ethSold;
@@ -344,8 +344,8 @@ contract LiquidERC20 is ERC20PointerSupply {
         address payable recipient
     ) internal returns (uint256) {
         require(deadline >= now); // dev: deadline passed
-        require(tokensSold > 0); // dev: must sell one or more tokens
-        require(minEth > 0); // dev: minEth not set
+        require(tokensSold != 0); // dev: must sell one or more tokens
+        require(minEth != 0); // dev: minEth not set
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethBought = getInputPrice(tokensSold, tokenReserve, address(this).balance);
         require(ethBought >= minEth); // dev: tokens not worth enough
@@ -404,7 +404,7 @@ contract LiquidERC20 is ERC20PointerSupply {
         address payable recipient
     ) internal returns (uint256) {
         require(deadline >= now); // dev: deadline passed
-        require(ethBought > 0); // dev: must buy more than 0 eth
+        require(ethBought != 0); // dev: must buy more than 0 eth
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 tokensSold = getOutputPrice(ethBought, tokenReserve, address(this).balance);
         require(maxTokens >= tokensSold); // dev: need more tokens to sell
@@ -463,7 +463,7 @@ contract LiquidERC20 is ERC20PointerSupply {
     /// @param ethSold The exact amount of ether you are selling.
     /// @return The amount of tokens that can be bought with `ethSold` ether.
     function getEthToTokenInputPrice(uint256 ethSold) public view returns(uint256) {
-        require(ethSold > 0); // dev: no eth to sell
+        require(ethSold != 0); // dev: no eth to sell
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         return getInputPrice(ethSold, address(this).balance, tokenReserve);
     }
@@ -480,7 +480,7 @@ contract LiquidERC20 is ERC20PointerSupply {
     /// @param tokensSold The exact amount of tokens you are selling.
     /// @return The amount of ether you receive for selling `tokensSold` tokens.
     function getTokenToEthInputPrice(uint256 tokensSold) public view returns (uint256) {
-        require(tokensSold > 0); // dev: can't sell less than one token
+        require(tokensSold != 0); // dev: can't sell less than one token
         uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
         return getInputPrice(tokensSold, tokenReserve, address(this).balance);
     }

--- a/contracts/LiquidERC20.sol
+++ b/contracts/LiquidERC20.sol
@@ -74,7 +74,7 @@ contract LiquidERC20 is ERC20PointerSupply {
 
         if (totalLiquidity != 0) {
             require(minLiquidity != 0); // dev: no min_liquidity specified
-            uint256 ethReserve = address(this).balance.sub(msg.value);
+            uint256 ethReserve = address(this).balance - msg.value;
             uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
             uint256 tokenAmount = msg.value.mul(tokenReserve).div(ethReserve).add(1);
             uint256 liquidityCreated = msg.value.mul(totalLiquidity).div(ethReserve);

--- a/contracts/LiquidERC20.sol
+++ b/contracts/LiquidERC20.sol
@@ -76,8 +76,8 @@ contract LiquidERC20 is ERC20PointerSupply {
             require(minLiquidity != 0); // dev: no min_liquidity specified
             uint256 ethReserve = address(this).balance - msg.value;
             uint256 tokenReserve = _totalMinted.sub(_totalBurned + _ownedSupply);
-            uint256 tokenAmount = msg.value.mul(tokenReserve).div(ethReserve).add(1);
-            uint256 liquidityCreated = msg.value.mul(totalLiquidity).div(ethReserve);
+            uint256 tokenAmount = msg.value.mul(tokenReserve) / ethReserve + 1;
+            uint256 liquidityCreated = msg.value.mul(totalLiquidity) / ethReserve;
             require(maxTokens >= tokenAmount); // dev: need more tokens
             require(liquidityCreated >= minLiquidity); // dev: not enough liquidity can be created
 
@@ -137,8 +137,8 @@ contract LiquidERC20 is ERC20PointerSupply {
         uint256 totalLiquidity = _poolTotalSupply;
         require(totalLiquidity != 0); // dev: no liquidity to remove
         uint256 tokenReserve = _totalMinted.sub(_totalBurned + _ownedSupply);
-        uint256 ethAmount = amount.mul(address(this).balance).div(totalLiquidity);
-        uint256 tokenAmount = amount.mul(tokenReserve).div(totalLiquidity);
+        uint256 ethAmount = amount.mul(address(this).balance) / totalLiquidity;
+        uint256 tokenAmount = amount.mul(tokenReserve) / totalLiquidity;
         require(ethAmount >= minEth); // dev: can't remove enough eth
         require(tokenAmount >= minTokens); // dev: can't remove enough tokens
 
@@ -176,7 +176,7 @@ contract LiquidERC20 is ERC20PointerSupply {
         uint256 inputAmountWithFee = inputAmount.mul(995);
         uint256 numerator = inputAmountWithFee.mul(outputReserve);
         uint256 denominator = inputReserve.mul(1000).add(inputAmountWithFee);
-        return numerator.div(denominator);
+        return numerator / denominator;
     }
 
     /// @dev Requirements:

--- a/contracts/LiquidERC20.sol
+++ b/contracts/LiquidERC20.sol
@@ -87,7 +87,7 @@ contract LiquidERC20 is ERC20PointerSupply {
 
             // remove LGTs from sender
             _balances[msg.sender] = _balances[msg.sender].sub(
-                tokenAmount, "LGT: token amount exceeds balance"
+                tokenAmount, "LGT: amount exceeds balance"
             );
             _ownedSupply = _ownedSupply.sub(tokenAmount);
 
@@ -103,7 +103,7 @@ contract LiquidERC20 is ERC20PointerSupply {
 
             // remove LGTs from sender
             _balances[msg.sender] = _balances[msg.sender].sub(
-                maxTokens, "LGT: token amount exceeds balance"
+                maxTokens, "LGT: amount exceeds balance"
             );
             _ownedSupply = _ownedSupply.sub(maxTokens);
 
@@ -282,7 +282,7 @@ contract LiquidERC20 is ERC20PointerSupply {
         uint256 tokenReserve = _totalMinted.sub(_totalBurned + _ownedSupply);
         uint256 ethReserve = address(this).balance.sub(maxEth);
         uint256 ethSold = getOutputPrice(tokensBought, ethReserve, tokenReserve);
-        uint256 ethRefund = maxEth.sub(ethSold, "LGT: not enough ETH to buy tokens");
+        uint256 ethRefund = maxEth.sub(ethSold, "LGT: not enough ETH");
         _balances[recipient] += tokensBought;
         _ownedSupply += tokensBought;
         if (ethRefund != 0) {
@@ -349,7 +349,7 @@ contract LiquidERC20 is ERC20PointerSupply {
         uint256 tokenReserve = _totalMinted.sub(_totalBurned + _ownedSupply);
         uint256 ethBought = getInputPrice(tokensSold, tokenReserve, address(this).balance);
         require(ethBought >= minEth); // dev: tokens not worth enough
-        _balances[buyer] = _balances[buyer].sub(tokensSold, "LGT: sell amount exceeds balance");
+        _balances[buyer] = _balances[buyer].sub(tokensSold, "LGT: amount exceeds balance");
         _ownedSupply = _ownedSupply.sub(tokensSold);
         recipient.transfer(ethBought);
         return ethBought;
@@ -408,7 +408,7 @@ contract LiquidERC20 is ERC20PointerSupply {
         uint256 tokenReserve = _totalMinted.sub(_totalBurned + _ownedSupply);
         uint256 tokensSold = getOutputPrice(ethBought, tokenReserve, address(this).balance);
         require(maxTokens >= tokensSold); // dev: need more tokens to sell
-        _balances[buyer] = _balances[buyer].sub(tokensSold, "LGT: sell amount exceeds balance");
+        _balances[buyer] = _balances[buyer].sub(tokensSold, "LGT: amount exceeds balance");
         _ownedSupply = _ownedSupply.sub(tokensSold);
         recipient.transfer(ethBought);
         return tokensSold;

--- a/contracts/LiquidGasToken.sol
+++ b/contracts/LiquidGasToken.sol
@@ -177,7 +177,7 @@ contract LiquidGasToken is LiquidERC20 {
         // uint256 totalMinted = _totalMinted; //stack too deep, this would save ~800 gas
         tokenAmount = maxTokens;
         if (totalLiquidity != 0) {
-            uint256 ethReserve = address(this).balance.sub(msg.value);
+            uint256 ethReserve = address(this).balance - msg.value;
             uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
             ethAmount = maxTokens.mul(ethReserve).div(tokenReserve).sub(1);
             if (ethAmount > msg.value) {
@@ -346,7 +346,7 @@ contract LiquidGasToken is LiquidERC20 {
         if (tokenReserve < amount) {
             return 0;
         }
-        uint256 ethReserve = address(this).balance.sub(msg.value);
+        uint256 ethReserve = address(this).balance - msg.value;
         uint256 ethSold = getOutputPrice(amount, ethReserve, tokenReserve);
         if (msg.value < ethSold) {
             return 0;
@@ -375,7 +375,7 @@ contract LiquidGasToken is LiquidERC20 {
         if (maxTokens == 0 || deadline <= now) {
             return 0;
         }
-        uint256 ethReserve = address(this).balance.sub(msg.value);
+        uint256 ethReserve = address(this).balance - msg.value;
         uint256 totalBurned = _totalBurned;
         uint256 tokenReserve = _totalMinted.sub(totalBurned).sub(_ownedSupply);
         uint256 tokensBought = getInputPrice(msg.value, ethReserve, tokenReserve);

--- a/contracts/LiquidGasToken.sol
+++ b/contracts/LiquidGasToken.sol
@@ -176,7 +176,6 @@ contract LiquidGasToken is LiquidERC20 {
         uint256 totalLiquidity = _poolTotalSupply;
         // uint256 totalMinted = _totalMinted; //stack too deep, this would save ~800 gas
         tokenAmount = maxTokens;
-        ethAmount = msg.value;
         if (totalLiquidity != 0) {
             uint256 ethReserve = address(this).balance.sub(msg.value);
             uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
@@ -191,6 +190,7 @@ contract LiquidGasToken is LiquidERC20 {
         } else {
             require(msg.value > 1000000000); // dev: initial eth below 1 gwei
             liquidityCreated = address(this).balance;
+            ethAmount = msg.value;
         }
 
         // Mint tokens directly to the liquidity pool

--- a/contracts/LiquidGasToken.sol
+++ b/contracts/LiquidGasToken.sol
@@ -177,14 +177,14 @@ contract LiquidGasToken is LiquidERC20 {
         uint256 totalMinted = _totalMinted;
         tokenAmount = maxTokens;
         if (totalLiquidity != 0) {
-            uint256 tokenReserve = totalMinted.sub(_totalBurned).sub(_ownedSupply);
+            uint256 tokenReserve = totalMinted.sub(_totalBurned + _ownedSupply);
             ethAmount = maxTokens.mul(address(this).balance - msg.value).div(tokenReserve).sub(1);
             if (ethAmount > msg.value) {
                 // reduce amount of tokens minted to provide maximum possible liquidity
-                tokenAmount = (msg.value.add(1)).mul(tokenReserve).div(address(this).balance - msg.value);
+                tokenAmount = (msg.value + 1).mul(tokenReserve) / (address(this).balance - msg.value);
                 ethAmount = tokenAmount.mul(address(this).balance - msg.value).div(tokenReserve).sub(1);
             }
-            liquidityCreated = ethAmount.mul(totalLiquidity).div(address(this).balance - msg.value);
+            liquidityCreated = ethAmount.mul(totalLiquidity) / (address(this).balance - msg.value);
             require(liquidityCreated >= minLiquidity); // dev: not enough liquidity can be created
         } else {
             require(msg.value > 1000000000); // dev: initial eth below 1 gwei
@@ -235,7 +235,7 @@ contract LiquidGasToken is LiquidERC20 {
         require(deadline >= now); // dev: deadline passed
         require(amount != 0); // dev: must sell one or more tokens
         uint256 totalMinted = _totalMinted;
-        uint256 tokenReserve = totalMinted.sub(_totalBurned).sub(_ownedSupply);
+        uint256 tokenReserve = totalMinted.sub(_totalBurned + _ownedSupply);
         uint256 ethBought = getInputPrice(amount, tokenReserve, address(this).balance);
         require(ethBought >= minEth); // dev: tokens not worth enough
         _createContracts(amount, totalMinted);
@@ -264,7 +264,7 @@ contract LiquidGasToken is LiquidERC20 {
         require(deadline >= now); // dev: deadline passed
         require(amount != 0); // dev: must sell one or more tokens
         uint256 totalMinted = _totalMinted;
-        uint256 tokenReserve = totalMinted.sub(_totalBurned).sub(_ownedSupply);
+        uint256 tokenReserve = totalMinted.sub(_totalBurned + _ownedSupply);
         uint256 ethBought = getInputPrice(amount, tokenReserve, address(this).balance);
         require(ethBought >= minEth); // dev: tokens not worth enough
         _createContracts(amount, totalMinted);
@@ -341,7 +341,7 @@ contract LiquidGasToken is LiquidERC20 {
             return 0;
         }
         uint256 totalBurned = _totalBurned;
-        uint256 tokenReserve = _totalMinted.sub(totalBurned).sub(_ownedSupply);
+        uint256 tokenReserve = _totalMinted.sub(totalBurned + _ownedSupply);
         if (tokenReserve < amount) {
             return 0;
         }
@@ -376,7 +376,7 @@ contract LiquidGasToken is LiquidERC20 {
         }
         uint256 ethReserve = address(this).balance - msg.value;
         uint256 totalBurned = _totalBurned;
-        uint256 tokenReserve = _totalMinted.sub(totalBurned).sub(_ownedSupply);
+        uint256 tokenReserve = _totalMinted.sub(totalBurned + _ownedSupply);
         uint256 tokensBought = getInputPrice(msg.value, ethReserve, tokenReserve);
         if (tokensBought == 0) {
             return 0;

--- a/contracts/LiquidGasToken.sol
+++ b/contracts/LiquidGasToken.sol
@@ -178,11 +178,11 @@ contract LiquidGasToken is LiquidERC20 {
         tokenAmount = maxTokens;
         if (totalLiquidity != 0) {
             uint256 tokenReserve = totalMinted.sub(_totalBurned + _ownedSupply);
-            ethAmount = maxTokens.mul(address(this).balance - msg.value).div(tokenReserve).sub(1);
+            ethAmount = (maxTokens.mul(address(this).balance - msg.value) / tokenReserve).sub(1);
             if (ethAmount > msg.value) {
                 // reduce amount of tokens minted to provide maximum possible liquidity
                 tokenAmount = (msg.value + 1).mul(tokenReserve) / (address(this).balance - msg.value);
-                ethAmount = tokenAmount.mul(address(this).balance - msg.value).div(tokenReserve).sub(1);
+                ethAmount = (tokenAmount.mul(address(this).balance - msg.value) / tokenReserve).sub(1);
             }
             liquidityCreated = ethAmount.mul(totalLiquidity) / (address(this).balance - msg.value);
             require(liquidityCreated >= minLiquidity); // dev: not enough liquidity can be created

--- a/contracts/LiquidGasToken.sol
+++ b/contracts/LiquidGasToken.sol
@@ -169,15 +169,15 @@ contract LiquidGasToken is LiquidERC20 {
         returns (uint256 tokenAmount, uint256 ethAmount, uint256 liquidityCreated)
     {
         require(deadline >= now); // dev: deadline passed
-        require(maxTokens > 0); // dev: can't mint less than 1 token
-        require(msg.value > 0); // dev: must provide ether to add liquidity
+        require(maxTokens != 0); // dev: can't mint less than 1 token
+        require(msg.value != 0); // dev: must provide ether to add liquidity
 
         // calculate optimum values for tokens and ether to add
         uint256 totalLiquidity = _poolTotalSupply;
         // uint256 totalMinted = _totalMinted; //stack too deep, this would save ~800 gas
         tokenAmount = maxTokens;
         ethAmount = msg.value;
-        if (totalLiquidity > 0) {
+        if (totalLiquidity != 0) {
             uint256 ethReserve = address(this).balance.sub(msg.value);
             uint256 tokenReserve = _totalMinted.sub(_totalBurned).sub(_ownedSupply);
             ethAmount = maxTokens.mul(ethReserve).div(tokenReserve).sub(1);
@@ -234,7 +234,7 @@ contract LiquidGasToken is LiquidERC20 {
         returns (uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(amount > 0); // dev: must sell one or more tokens
+        require(amount != 0); // dev: must sell one or more tokens
         uint256 totalMinted = _totalMinted;
         uint256 tokenReserve = totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethBought = getInputPrice(amount, tokenReserve, address(this).balance);
@@ -263,7 +263,7 @@ contract LiquidGasToken is LiquidERC20 {
         returns (uint256)
     {
         require(deadline >= now); // dev: deadline passed
-        require(amount > 0); // dev: must sell one or more tokens
+        require(amount != 0); // dev: must sell one or more tokens
         uint256 totalMinted = _totalMinted;
         uint256 tokenReserve = totalMinted.sub(_totalBurned).sub(_ownedSupply);
         uint256 ethBought = getInputPrice(amount, tokenReserve, address(this).balance);
@@ -338,7 +338,7 @@ contract LiquidGasToken is LiquidERC20 {
         payable
         returns (uint256)
     {
-        if (deadline <= now || amount <= 0) {
+        if (amount == 0 || deadline <= now) {
             return 0;
         }
         uint256 totalBurned = _totalBurned;
@@ -353,7 +353,7 @@ contract LiquidGasToken is LiquidERC20 {
         }
         uint256 ethRefund = msg.value - ethSold;
         _destroyContracts(amount, totalBurned);
-        if (ethRefund > 0) {
+        if (ethRefund != 0) {
             refundTo.transfer(ethRefund);
         }
         return ethSold;
@@ -372,14 +372,14 @@ contract LiquidGasToken is LiquidERC20 {
         payable
         returns (uint256)
     {
-        if (deadline <= now || maxTokens <= 0) {
+        if (maxTokens == 0 || deadline <= now) {
             return 0;
         }
         uint256 ethReserve = address(this).balance.sub(msg.value);
         uint256 totalBurned = _totalBurned;
         uint256 tokenReserve = _totalMinted.sub(totalBurned).sub(_ownedSupply);
         uint256 tokensBought = getInputPrice(msg.value, ethReserve, tokenReserve);
-        if (tokensBought <= 0) {
+        if (tokensBought == 0) {
             return 0;
         } else if (tokensBought > maxTokens) {
             tokensBought = maxTokens;


### PR DESCRIPTION
* favor equality vs greater-than / less-than comparisons with zero in order to take advantage of `ISZERO` instruction
* reorder `||` if test conditions so cheaper evaluation comes first - saves gas from short circuiting
* remove `ethReserve` local variable in `mintToSellTo` - repeated calls to `SELFBALANCE` and `CALLVALUE` cost less than the multiple `SLOAD`s required from `_totalMinted`
* remove some redundant safemath checks